### PR TITLE
Linux 対応のための修正

### DIFF
--- a/app/resolve/Python/rs_resolve/gui/__init__.py
+++ b/app/resolve/Python/rs_resolve/gui/__init__.py
@@ -1,19 +1,19 @@
 import subprocess
 
-import pygetwindow
+import pywinctl
 
 from rs.core import util
 
 
 def get_resolve_window(pj_name):
-    for t in pygetwindow.getAllTitles():
+    for t in pywinctl.getAllTitles():
         if not util.IS_MAC:
             flag = t.startswith('DaVinci Resolve') and t.endswith(pj_name)
             flag = flag or t.startswith('DaVinci Resolve by Blackmagic Design')
         else:
             flag = t == pj_name
         if flag:
-            return pygetwindow.getWindowsWithTitle(t)[0]
+            return pywinctl.getWindowsWithTitle(t)[0]
     return None
 
 

--- a/library/python/rs/core/app/resolve.py
+++ b/library/python/rs/core/app/resolve.py
@@ -25,7 +25,7 @@ class Resolve(Fusion):
         env = super().get_env()
         # PYTHONPATH
         env.add_path(EnvKey.PYTHONPATH, pre=[
-            config.APP_SET_PATH.joinpath('resolve', 'python'),
+            config.APP_SET_PATH.joinpath('resolve', 'Python'),
         ])
         return env
 

--- a/library/python/rs/core/config.py
+++ b/library/python/rs/core/config.py
@@ -38,7 +38,7 @@ elif util.IS_MAC:
     FUSION_USER_PATH = APPDATA_PATH.joinpath('Blackmagic Design', 'Fusion')
 else:
     APPDATA_PATH = Path(os.path.expandvars('$HOME')).joinpath('.local', 'share')
-    RESOLVE_USER_PATH = APPDATA_PATH.joinpath('DaVinci Resolve', 'Fusion')
+    RESOLVE_USER_PATH = APPDATA_PATH.joinpath('DaVinciResolve', 'Fusion')
     FUSION_USER_PATH = APPDATA_PATH.joinpath('Fusion')
 
 ENCODING_LIST = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,8 +32,8 @@ pooch==1.7.0
 psd-tools==1.9.28
 PyAutoGUI==0.9.54
 pycparser==2.21
-PyGetWindow==0.0.9
 pykakasi==2.2.1
+PyMonCtl==0.7
 PyMsgBox==1.0.9
 pyperclip==1.8.2
 PyRect==0.2.0
@@ -45,6 +45,8 @@ PySide6-Essentials==6.5.2
 pytsmod==0.3.6
 pytweening==1.0.7
 PyWavelets==1.4.1
+PyWinBox==0.6
+PyWinCtl==0.3
 pyworld==0.3.4
 requests==2.31.0
 scikit-image==0.21.0


### PR DESCRIPTION
Linux 環境で立ち絵を口パクする方法を探してたので、非常に助かりました。

立ち絵を分割し、目パチ口パクするところまで動作確認しましたが、
そのままでは動かなかったので必要だった変更をまとめています。
Windows および Mac については環境がないので動作確認できていません。

動作環境
|                          | バージョン |
| ----------------- | ------------ |
| DaVinci Resolve | 18.6.0         |
| Python (pyenv)  | 3.10.13       |

PyGetWindow を [PyWinCtl](https://github.com/Kalmat/PyWinCtl) に置き換えている理由ですが、
PyGetWindow はメンテされておらず、クロスプラットフォームといいつつ実質 Windows しか対応していません。
このため PyGetWindow をフォークした後継プロジェクトの PyWinCtl に置き換えています。

単純にドロップインで動くはずですが Windows, Mac 環境で不具合があるようでしたら教えていただけますでしょうか。
使われている箇所が限定的なので VoiceDropper が動けば他も問題ないとは思います。