### PR TITLE
[VoiceDropper/VoiceBIN_Assistant] Davinci19.1で発生したfusionUI.UIManager有料化への一時対応

### DIFF
--- a/app/fusion/UserPath/Scripts/Edit/RS/VoiceBin_Assistant.py3
+++ b/app/fusion/UserPath/Scripts/Edit/RS/VoiceBin_Assistant.py3
@@ -1,24 +1,27 @@
 win_name = 'VoiceBin アシスタント'
 
-ui = fu.UIManager
-disp = bmd.UIDispatcher(ui)
-dlg = disp.AddWindow(
-    {'WindowTitle': win_name, 'ID': win_name + 'Splash', },
-    [
-        ui.VGroup({"Spacing": 5, },
-                  [
-                      ui.Label({
-                          'ID': 'Message',
-                          'Text': win_name + '\n起動中...',
-                          'Alignment': {'AlignHCenter': True, 'AlignVCenter': True},
-                          'StyleSheet': 'font-size: 24px;',
-                      }),
-                  ]),
-    ]
-)
-dlg.Show()
-from rs_resolve.tool.voice_bin_assistant import run
+try:
+  ui = fu.UIManager
+  disp = bmd.UIDispatcher(ui)
+  dlg = disp.AddWindow(
+      {'WindowTitle': win_name, 'ID': win_name + 'Splash', },
+      [
+          ui.VGroup({"Spacing": 5, },
+                    [
+                        ui.Label({
+                            'ID': 'Message',
+                            'Text': win_name + '\n起動中...',
+                            'Alignment': {'AlignHCenter': True, 'AlignVCenter': True},
+                            'StyleSheet': 'font-size: 24px;',
+                        }),
+                    ]),
+      ]
+  )
+  dlg.Show()
+  from rs_resolve.tool.voice_bin_assistant import run
 
-dlg.Hide()
+  dlg.Hide()
+except:
+  from rs_resolve.tool.voice_bin_assistant import run
 
 run(app)

--- a/app/fusion/UserPath/Scripts/Edit/RS/VoiceDropper.py3
+++ b/app/fusion/UserPath/Scripts/Edit/RS/VoiceDropper.py3
@@ -1,24 +1,27 @@
 win_name = 'VoiceDropper'
 
-ui = fu.UIManager
-disp = bmd.UIDispatcher(ui)
-dlg = disp.AddWindow(
-    {'WindowTitle': win_name, 'ID': win_name + 'Splash', },
-    [
-        ui.VGroup({"Spacing": 5, },
-                  [
-                      ui.Label({
-                          'ID': 'Message',
-                          'Text': win_name + '\n起動中...',
-                          'Alignment': {'AlignHCenter': True, 'AlignVCenter': True},
-                          'StyleSheet': 'font-size: 24px;',
-                      }),
-                  ]),
-    ]
-)
+try:
+  ui = fu.UIManager
+  disp = bmd.UIDispatcher(ui)
+  dlg = disp.AddWindow(
+      {'WindowTitle': win_name, 'ID': win_name + 'Splash', },
+      [
+          ui.VGroup({"Spacing": 5, },
+                    [
+                        ui.Label({
+                            'ID': 'Message',
+                            'Text': win_name + '\n起動中...',
+                            'Alignment': {'AlignHCenter': True, 'AlignVCenter': True},
+                            'StyleSheet': 'font-size: 24px;',
+                        }),
+                    ]),
+      ]
+  )
 
-dlg.Show()
-from rs_resolve.tool.voice_dropper import run
-dlg.Hide()
+  dlg.Show()
+  from rs_resolve.tool.voice_dropper import run
+  dlg.Hide()
+except:
+  from rs_resolve.tool.voice_dropper import run
 
 run(app)


### PR DESCRIPTION
Davinci Resolve 19.1でFusionUI.UIManagerが有料版限定となったようです

これにより**[VoiceDropper/VoiceBIN_Assistant] ** を立ち上げると、購入催促の画面と以下ようなエラーが出ることをコンソール上で確認
```
***\app\fusion\UserPath\Scripts\Edit\RS\VoiceDropper.py3", line 8, in <module>
    ui.VGroup({"Spacing": 5, },
AttributeError: 'NoneType' object has no attribute 'VGroup'
```


一時しのぎの対応として
`try-except`文で対応しました