### PR TITLE
[VoiceDropper/subtitle2textPlus_typeB] エンドフレームの修正

### DIFF
--- a/app/resolve/python/rs_resolve/tool/subtitle2textPlus_typeB/subtitle2textPlus_typeB.py
+++ b/app/resolve/python/rs_resolve/tool/subtitle2textPlus_typeB/subtitle2textPlus_typeB.py
@@ -191,7 +191,7 @@ class MainWindow(QMainWindow):
             text_plus = media_pool.AppendToTimeline([{
                 'mediaPoolItem': text_template,
                 'startFrame': 0,
-                'endFrame': ef - sf - 1,
+                'endFrame': ef - sf,
                 'trackIndex': v_index,
                 'mediaType': 1,
                 'recordFrame': sf,

--- a/app/resolve/python/rs_resolve/tool/voice_dropper/voice_dropper.py
+++ b/app/resolve/python/rs_resolve/tool/voice_dropper/voice_dropper.py
@@ -475,7 +475,7 @@ class MainWindow(QMainWindow):
             if clip is None:
                 continue
 
-            duration = clip.GetDuration()
+            duration = clip.GetDuration() + 1
 
             # Text+の挿入
             self.add2log('Insert Text Clip: Start')
@@ -483,7 +483,7 @@ class MainWindow(QMainWindow):
             text_plus = media_pool.AppendToTimeline([{
                 'mediaPoolItem': text_template,
                 'startFrame': 0,
-                'endFrame': duration - 1 + data.extend,  # 1フレーム短くする (start 0 end 0 で 尺は1フレーム)
+                'endFrame': duration + data.extend,
                 'trackIndex': video_index,
                 'mediaType': 1,
                 'recordFrame': current_frame,
@@ -846,7 +846,7 @@ class MainWindow(QMainWindow):
             del_list = []
             for clip in timeline.GetItemListInTrack('video', v_index):
                 if clip.GetStart() < v_ef and v_sf < clip.GetEnd():
-                    c_frame = clip.GetStart() + clip.GetDuration() // 2
+                    c_frame = clip.GetStart() + clip.GetDuration() // 2 + 1
                     _wav = get_item(timeline, 'audio', a_index, c_frame)
                     if _wav is None:
                         del_list.append(clip)


### PR DESCRIPTION
https://github.com/nakano000/Resolve_Script/issues/21 への対処+ 同様の問題を抱えているVoiceDropperへの対象

クリップの長さを調整する機能の修正

Davinci Resolve 18 -> 19で
AppendToTimeline()の"endFrame"キーの想定が変わったか
getDuration()の返り値が変わったのだろうと思われる
